### PR TITLE
deployスクリプトを作成する

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+const fs = require('fs');
+const { SCREEPS_LOCAL_PATH } = process.env;
+
+const path = './src/';
+const screepLocalPath = SCREEPS_LOCAL_PATH;
+
+fs.readdir(path, (err, files) => {
+  if (err) {
+    console.error("Could not list the directory.", err);
+    return;
+  }
+
+  for (let index = 0; index < files.length - 1; index++) {
+    const element = files[index];
+    fs.copyFileSync(path + element, screepLocalPath + '/' + element);
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@types/screeps-arena": "^0.0.1"
+        "@types/screeps-arena": "^0.0.1",
+        "dotenv": "^16.3.1"
       }
     },
     "node_modules/@types/screeps-arena": {
@@ -17,6 +18,18 @@
       "resolved": "https://registry.npmjs.org/@types/screeps-arena/-/screeps-arena-0.0.1.tgz",
       "integrity": "sha512-add9EMxpCA2WwyXLpIoqdNFNZgt1Nx3kG6PZd3l03/Y9wzFQ1Rtwb/+66+bnRPeeNunOYet2PU5iHme7n+9ywA==",
       "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
     }
   },
   "dependencies": {
@@ -24,6 +37,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@types/screeps-arena/-/screeps-arena-0.0.1.tgz",
       "integrity": "sha512-add9EMxpCA2WwyXLpIoqdNFNZgt1Nx3kG6PZd3l03/Y9wzFQ1Rtwb/+66+bnRPeeNunOYet2PU5iHme7n+9ywA==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy": "node deploy.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/yuya-0928/ScreepsPlayground#readme",
   "devDependencies": {
-    "@types/screeps-arena": "^0.0.1"
+    "@types/screeps-arena": "^0.0.1",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## やったこと
- npm run deployを実行すると、Screepの実行環境にJSファイルをコピーして、本番環境にコードを反映する

## 次やること
- [x] npm run deployで、リポジトリ上のコードをlocalのScreeps/scripts/screeps.com/defaultにコピーするコードを書く
- [ ] lint, prettierの導入をする
- [ ] mainが肥大化しているので、処理を細かく分ける
- [ ] nodemonを導入して、スクリプトに変更があった時に、自動でdeployの処理が走るようにする